### PR TITLE
feat(infra): adding capability to oidc role to assume role at customer

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -27,7 +27,7 @@ locals {
       ]
     }
   }
-  principals_account_ids = {
-    for key, arn in var.principals_readonly_access_all : key => regex("arn:aws:iam::(\\d+):root", arn)[0]
+  principals_readonly_access_all = {
+    for tenant, account in var.principal_account_ids : tenant => format("arn:aws:iam::%s:root", account)
   }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -27,4 +27,7 @@ locals {
       ]
     }
   }
+  principals_account_ids = {
+    for key, arn in var.principals_readonly_access_all : key => regex("arn:aws:iam::(\\d+):root", arn)[0]
+  }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,16 +11,12 @@ module "label" {
   stage     = "shared"
 }
 
-locals {
-  principals = var.principals_readonly_access_all
-}
-
 ## TODO: Allow Organization Access: https://aws.amazon.com/blogs/containers/sharing-amazon-ecr-repositories-with-multiple-accounts-using-aws-organizations/
 module "ecr" {
   source                     = "cloudposse/ecr/aws"
   version                    = "0.39.0"
   for_each                   = toset(var.ecr_repository_names)
-  principals_readonly_access = values(var.principals_readonly_access_all)
+  principals_readonly_access = values(local.principals_readonly_access_all)
   principals_push_access     = var.principals_push_access_all
   image_names                = [each.value]
   image_tag_mutability       = "MUTABLE"
@@ -40,7 +36,7 @@ data "aws_iam_policy_document" "cache_bucket" {
 }
 
 data "aws_iam_policy_document" "librechat_config" {
-  for_each = var.principals_readonly_access_all
+  for_each = local.principals_readonly_access_all
   statement {
     sid    = each.key
     effect = "Allow"

--- a/terraform/oidc.tf
+++ b/terraform/oidc.tf
@@ -24,6 +24,20 @@ resource "aws_iam_role" "genai" {
   assume_role_policy   = data.aws_iam_policy_document.genai_assume.json
 }
 
+data "aws_iam_policy_document" "customer_deployer_access" {
+  for_each = local.principals_account_ids
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = [format("arn:aws:iam::%s:role/ecs-deployment-role", each.value)]
+    }
+  }
+}
+
 data "aws_iam_policy_document" "genai_assume" {
 
   dynamic "statement" {
@@ -130,3 +144,12 @@ resource "aws_iam_role_policy_attachment" "genai_s3" {
   role       = aws_iam_role.genai.name
   policy_arn = aws_iam_policy.genai_s3.arn
 }
+
+resource "aws_iam_role_policy" "genai_customer_deployer" {
+  for_each = data.aws_iam_policy_document.customer_deployer_access
+  name     = format("genai-customer-deployer-%s", each.key)
+  policy   = each.value.json
+  role     = aws_iam_role.genai.name
+}
+
+

--- a/terraform/oidc.tf
+++ b/terraform/oidc.tf
@@ -25,7 +25,7 @@ resource "aws_iam_role" "genai" {
 }
 
 data "aws_iam_policy_document" "customer_deployer_access" {
-  for_each = local.principals_account_ids
+  for_each = var.principal_account_ids
   statement {
     effect = "Allow"
     actions = [

--- a/terraform/oidc.tf
+++ b/terraform/oidc.tf
@@ -31,10 +31,9 @@ data "aws_iam_policy_document" "customer_deployer_access" {
     actions = [
       "sts:AssumeRole",
     ]
-    principals {
-      type        = "AWS"
-      identifiers = [format("arn:aws:iam::%s:role/ecs-deployment-role", each.value)]
-    }
+    resources = [
+      format("arn:aws:iam::%s:role/ecs-deployment-role", each.value),
+    ]
   }
 }
 

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -5,12 +5,18 @@ ecr_repository_names = [
 
 ## Key = bucket prefix in s3
 ## Value = AWS account principal
-principals_readonly_access_all = {
-  "snorri"                = "arn:aws:iam::746669190533:root",
-  "apro-datalake-sandbox" = "arn:aws:iam::515966504419:root",
-  "apro"                  = "arn:aws:iam::183631334210:root",
-  "byko"                  = "arn:aws:iam::741448944625:root"
+principal_account_ids = {
+  "snorri"                = "746669190533",
+  "apro-datalake-sandbox" = "515966504419",
+  "apro"                  = "183631334210",
+  "byko"                  = "741448944625"
 }
 
+# principals_readonly_access_all = {
+#   "snorri"                = "arn:aws:iam::746669190533:root",
+#   "apro-datalake-sandbox" = "arn:aws:iam::515966504419:root",
+#   "apro"                  = "arn:aws:iam::183631334210:root",
+#   "byko"                  = "arn:aws:iam::741448944625:root"
+# }
 # TODO: We need to add a github role here for our pipelines.
 principals_push_access_all = []

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,6 @@
-variable "principals_readonly_access_all" {
-  description = "The list of principals that have readonly access to the ECR repositories"
+variable "principal_account_ids" {
+  description = "Map of principal account ids"
   type        = map(string)
-  default     = {}
 }
 
 variable "principals_push_access_all" {


### PR DESCRIPTION
Adds capability for our OIDC role to assume roles at customers. 
The role in question is created by the Accelerator and always has the same name, so it's just a matter of getting the accound_id which can be found in terraform vars. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration to dynamically extract and standardize account identifiers.
  - Introduced new access control policies that allow designated principals to assume roles, optimizing permissions management.
  - Added a new variable for principal account IDs to streamline access management.

- **Bug Fixes**
  - Removed deprecated variable references to improve code clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->