### PR TITLE
feat: serve custom endpoints their declared models intersected with the live catalog

### DIFF
--- a/api/server/controllers/EndpointController.js
+++ b/api/server/controllers/EndpointController.js
@@ -1,7 +1,12 @@
 const { getEndpointsConfig } = require('~/server/services/Config');
 
 async function endpointController(req, res) {
-  const endpointsConfig = await getEndpointsConfig(req);
+  /**
+   * The one caller that answers "what may this user be offered": the selector,
+   * the Agent Builder and spec pruning all derive from this response, so an
+   * endpoint with nothing to serve is withheld here and nowhere else.
+   */
+  const endpointsConfig = await getEndpointsConfig(req, { withholdEmpty: true });
   res.send(JSON.stringify(endpointsConfig));
 }
 

--- a/api/server/controllers/ModelController.js
+++ b/api/server/controllers/ModelController.js
@@ -1,17 +1,15 @@
 const { logger } = require('@librechat/data-schemas');
-const { loadDefaultModels, loadConfigModels } = require('~/server/services/Config');
+const { getModelsConfig } = require('~/server/services/Config');
 
-const getModelsConfig = (req) => loadModels(req);
-
-async function loadModels(req) {
-  const defaultModelsConfig = await loadDefaultModels(req);
-  const customModelsConfig = await loadConfigModels(req);
-  return { ...defaultModelsConfig, ...customModelsConfig };
-}
+/**
+ * The request-memoized accessor is the single entry point for a request's
+ * models config; `loadModels` stays exported for callers that predate it.
+ */
+const loadModels = (req) => getModelsConfig(req);
 
 async function modelController(req, res) {
   try {
-    const modelConfig = await loadModels(req);
+    const modelConfig = await getModelsConfig(req);
     res.send(modelConfig);
   } catch (error) {
     logger.error('Error fetching models:', error);

--- a/api/server/middleware/__tests__/validateModel.spec.js
+++ b/api/server/middleware/__tests__/validateModel.spec.js
@@ -175,4 +175,30 @@ describe('validateModel', () => {
       expect(handleError).toHaveBeenCalledWith(res, { text: 'Models not loaded' });
     });
   });
+
+  it('rejects without logging a violation when the endpoint has no models', async () => {
+    getModelsConfig.mockResolvedValue({ openAI: [] });
+
+    await validateModel(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(logViolation).not.toHaveBeenCalled();
+    expect(handleError).toHaveBeenCalledWith(res, { text: 'Endpoint unavailable' });
+  });
+
+  it('still logs a violation for an unlisted model when the endpoint has models', async () => {
+    req.body.model = 'not-a-real-model';
+
+    await validateModel(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(logViolation).toHaveBeenCalledWith(
+      req,
+      res,
+      ViolationTypes.ILLEGAL_MODEL_REQUEST,
+      { type: ViolationTypes.ILLEGAL_MODEL_REQUEST },
+      1,
+    );
+    expect(handleError).toHaveBeenCalledWith(res, { text: 'Illegal model request' });
+  });
 });

--- a/api/server/middleware/validateModel.js
+++ b/api/server/middleware/validateModel.js
@@ -1,4 +1,5 @@
 const { handleError } = require('@librechat/api');
+const { logger } = require('@librechat/data-schemas');
 const { ViolationTypes } = require('librechat-data-provider');
 const { getModelsConfig } = require('~/server/controllers/ModelController');
 const { getEndpointsConfig } = require('~/server/services/Config');
@@ -52,6 +53,18 @@ const validateModel = async (req, res, next) => {
 
   if (validModel) {
     return next();
+  }
+
+  /* An endpoint with no models is unavailable to this request — the gateway
+     serves none of what it declares, or none for this user's grants. Any model
+     named against it is unserveable rather than illegitimate, and a stored
+     conversation or agent pointing at it would otherwise earn its owner a
+     violation, and eventually a ban, for a change in configuration. */
+  if (availableModels.length === 0) {
+    logger.debug(
+      `[validateModel] No models available for endpoint "${endpoint}"; rejecting "${model}" without logging a violation`,
+    );
+    return handleError(res, { text: 'Endpoint unavailable' });
   }
 
   const { ILLEGAL_MODEL_REQ_SCORE: score = 1 } = process.env ?? {};

--- a/api/server/services/Config/__tests__/getModelsConfig.spec.js
+++ b/api/server/services/Config/__tests__/getModelsConfig.spec.js
@@ -1,0 +1,64 @@
+jest.mock('../loadConfigModels');
+jest.mock('../loadDefaultModels');
+
+const loadConfigModels = require('../loadConfigModels');
+const loadDefaultModels = require('../loadDefaultModels');
+const getModelsConfig = require('../getModelsConfig');
+
+describe('getModelsConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loadDefaultModels.mockResolvedValue({ bedrock: ['anthropic.claude'] });
+    loadConfigModels.mockResolvedValue({ Claude: ['claude-sonnet-5'] });
+  });
+
+  it('merges default and custom models', async () => {
+    const result = await getModelsConfig({ user: { id: 'u1' } });
+
+    expect(result).toEqual({
+      bedrock: ['anthropic.claude'],
+      Claude: ['claude-sonnet-5'],
+    });
+  });
+
+  it('resolves once per request, however many callers ask', async () => {
+    const req = { user: { id: 'u1' } };
+
+    const [first, second, third] = await Promise.all([
+      getModelsConfig(req),
+      getModelsConfig(req),
+      getModelsConfig(req),
+    ]);
+    await getModelsConfig(req);
+
+    expect(loadConfigModels).toHaveBeenCalledTimes(1);
+    expect(loadDefaultModels).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it('does not share a result between requests', async () => {
+    loadConfigModels
+      .mockResolvedValueOnce({ Claude: ['claude-sonnet-5'] })
+      .mockResolvedValueOnce({ Claude: [] });
+
+    const alice = await getModelsConfig({ user: { id: 'alice' } });
+    const bob = await getModelsConfig({ user: { id: 'bob' } });
+
+    expect(alice.Claude).toEqual(['claude-sonnet-5']);
+    expect(bob.Claude).toEqual([]);
+    expect(loadConfigModels).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets a later caller retry after a failure instead of inheriting it', async () => {
+    const req = { user: { id: 'u1' } };
+    loadConfigModels.mockRejectedValueOnce(new Error('gateway unreachable'));
+
+    await expect(getModelsConfig(req)).rejects.toThrow('gateway unreachable');
+
+    loadConfigModels.mockResolvedValueOnce({ Claude: ['claude-sonnet-5'] });
+    await expect(getModelsConfig(req)).resolves.toEqual(
+      expect.objectContaining({ Claude: ['claude-sonnet-5'] }),
+    );
+  });
+});

--- a/api/server/services/Config/getEndpointsConfig.js
+++ b/api/server/services/Config/getEndpointsConfig.js
@@ -1,10 +1,15 @@
 const { createEndpointsConfigService } = require('@librechat/api');
 const loadDefaultEndpointsConfig = require('./loadDefaultEConfig');
+const getModelsConfig = require('./getModelsConfig');
 const { getAppConfig } = require('./app');
 
 const { getEndpointsConfig, checkCapability } = createEndpointsConfigService({
   getAppConfig,
   loadDefaultEndpointsConfig,
+  // Lets a custom endpoint with no models available to this request be
+  // withheld. Memoized per request, so sharing it with the models route, spec
+  // pruning and model validation costs no extra catalog fetch.
+  getModelsConfig,
 });
 
 module.exports = { getEndpointsConfig, checkCapability };

--- a/api/server/services/Config/getEndpointsConfig.js
+++ b/api/server/services/Config/getEndpointsConfig.js
@@ -6,9 +6,10 @@ const { getAppConfig } = require('./app');
 const { getEndpointsConfig, checkCapability } = createEndpointsConfigService({
   getAppConfig,
   loadDefaultEndpointsConfig,
-  // Lets a custom endpoint with no models available to this request be
-  // withheld. Memoized per request, so sharing it with the models route, spec
-  // pruning and model validation costs no extra catalog fetch.
+  // Lets a caller passing `withholdEmpty` drop a custom endpoint with no models
+  // available to this request. Memoized per request, so sharing it with the
+  // models route, spec pruning and model validation costs no extra catalog
+  // fetch.
   getModelsConfig,
 });
 

--- a/api/server/services/Config/getModelsConfig.js
+++ b/api/server/services/Config/getModelsConfig.js
@@ -1,0 +1,53 @@
+const loadConfigModels = require('./loadConfigModels');
+const loadDefaultModels = require('./loadDefaultModels');
+
+/**
+ * Per-request memo of the resolved models config.
+ *
+ * Serving a single page resolves this several times over — the models route,
+ * the startup-config route pruning model specs, the endpoints config deciding
+ * which endpoints have anything to serve, model validation on submit, and
+ * agent initialization — and every call re-fetches each gateway's catalog. The
+ * shared `MODEL_QUERIES` cache cannot absorb it: `fetchModels` deliberately
+ * skips that cache whenever an endpoint forwards user-bound headers, since one
+ * user's filtered list must never be served to another.
+ *
+ * Keyed on the request object, so an entry cannot outlive the identity it was
+ * resolved for and is collected with the request. Callers share one object —
+ * treat the result as read-only.
+ *
+ * @type {WeakMap<object, Promise<Record<string, string[]>>>}
+ */
+const inFlight = new WeakMap();
+
+async function resolveModelsConfig(req) {
+  const defaultModelsConfig = await loadDefaultModels(req);
+  const customModelsConfig = await loadConfigModels(req);
+  return { ...defaultModelsConfig, ...customModelsConfig };
+}
+
+/**
+ * @param {ServerRequest} req
+ * @returns {Promise<Record<string, string[]>>}
+ */
+function getModelsConfig(req) {
+  if (req == null || typeof req !== 'object') {
+    return resolveModelsConfig(req);
+  }
+
+  const pending = inFlight.get(req);
+  if (pending != null) {
+    return pending;
+  }
+
+  /* Evict on failure so a later caller in the same request retries rather than
+     inheriting a settled rejection. */
+  const resolving = resolveModelsConfig(req).catch((error) => {
+    inFlight.delete(req);
+    throw error;
+  });
+  inFlight.set(req, resolving);
+  return resolving;
+}
+
+module.exports = getModelsConfig;

--- a/api/server/services/Config/index.js
+++ b/api/server/services/Config/index.js
@@ -4,6 +4,7 @@ const { config } = require('./EndpointService');
 const getCachedTools = require('./getCachedTools');
 const loadCustomConfig = require('./loadCustomConfig');
 const loadConfigModels = require('./loadConfigModels');
+const getModelsConfig = require('./getModelsConfig');
 const loadDefaultModels = require('./loadDefaultModels');
 const getEndpointsConfig = require('./getEndpointsConfig');
 const loadAsyncEndpoints = require('./loadAsyncEndpoints');
@@ -13,6 +14,7 @@ module.exports = {
   loadCustomConfig,
   loadConfigModels,
   loadDefaultModels,
+  getModelsConfig,
   loadAsyncEndpoints,
   ...appConfig,
   ...getCachedTools,

--- a/client/src/common/selector.ts
+++ b/client/src/common/selector.ts
@@ -9,6 +9,8 @@ export interface Endpoint {
   icon: React.ReactNode;
   agentNames?: Record<string, string>;
   assistantNames?: Record<string, string>;
+  /** Display-only labels for this endpoint's models, keyed by model id. */
+  modelLabels?: Record<string, string>;
   modelIcons?: Record<string, string | undefined>;
   showMarketplace?: boolean;
   searchAliases?: string[];

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
@@ -14,7 +14,7 @@ import { useAgentsMapContext, useAssistantsMapContext, useLiveAnnouncer } from '
 import { useGetEndpointsQuery, useListAgentsQuery } from '~/data-provider';
 import { useModelSelectorChatContext } from './ModelSelectorChatContext';
 import useSelectMention from '~/hooks/Input/useSelectMention';
-import { filterItems } from './utils';
+import { filterItems, getModelName } from './utils';
 
 type ModelSelectorContextType = {
   // State
@@ -98,12 +98,13 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
 
   const getModelDisplayName = useCallback(
     (endpoint: Endpoint, model: string): string => {
-      if (isAgentsEndpoint(endpoint.value)) {
-        return endpoint.agentNames?.[model] ?? agentsMap?.[model]?.name ?? model;
+      const customName = getModelName(endpoint, model);
+      if (customName != null) {
+        return customName;
       }
 
-      if (isAssistantsEndpoint(endpoint.value)) {
-        return endpoint.assistantNames?.[model] ?? model;
+      if (isAgentsEndpoint(endpoint.value)) {
+        return agentsMap?.[model]?.name ?? model;
       }
 
       return model;

--- a/client/src/components/Chat/Menus/Endpoints/__tests__/utils.test.ts
+++ b/client/src/components/Chat/Menus/Endpoints/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import type { useLocalize } from '~/hooks';
 import type { Endpoint } from '~/common';
-import { filterItems } from '../utils';
+import { filterItems, filterModels, getDisplayValue, getModelName } from '../utils';
 
 const agentsEndpoint: Endpoint = {
   value: 'agents',
@@ -42,5 +42,96 @@ describe('model selector utilities', () => {
   it('does not match agents when there are no selectable agent options', () => {
     const results = filterItems([disabledAgentsEndpoint], 'my agents', undefined, undefined);
     expect(results).toEqual([]);
+  });
+});
+
+const claudeEndpoint: Endpoint = {
+  value: 'Claude',
+  label: 'Claude',
+  hasModels: true,
+  icon: null,
+  models: [{ name: 'claude-opus-4-8' }, { name: 'claude-sonnet-4-6' }],
+  modelLabels: { 'claude-opus-4-8': 'Opus 4.8' },
+};
+
+describe('getModelName', () => {
+  it('returns the declared label for a labelled model', () => {
+    expect(getModelName(claudeEndpoint, 'claude-opus-4-8')).toBe('Opus 4.8');
+  });
+
+  it('returns undefined for a model with no label, so callers fall back to the id', () => {
+    expect(getModelName(claudeEndpoint, 'claude-sonnet-4-6')).toBeUndefined();
+  });
+
+  it('ignores modelLabels on agents and assistants endpoints', () => {
+    const agents: Endpoint = {
+      value: 'agents',
+      label: 'Agents',
+      hasModels: true,
+      icon: null,
+      agentNames: { 'agent-1': 'Support Agent', 'agent-2': '' },
+      modelLabels: { 'agent-1': 'Never Rendered' },
+    };
+    expect(getModelName(agents, 'agent-1')).toBe('Support Agent');
+    /* An unnamed agent stores '', which must read as no name at all. */
+    expect(getModelName(agents, 'agent-2')).toBeUndefined();
+  });
+
+  it('tolerates a missing endpoint or model', () => {
+    expect(getModelName(null, 'claude-opus-4-8')).toBeUndefined();
+    expect(getModelName(claudeEndpoint, null)).toBeUndefined();
+  });
+});
+
+describe('label-aware search', () => {
+  it('matches an endpoint on a model label', () => {
+    expect(filterItems([claudeEndpoint], 'opus 4.8', undefined, undefined)).toEqual([
+      claudeEndpoint,
+    ]);
+  });
+
+  it('still matches an endpoint on the raw model id', () => {
+    expect(filterItems([claudeEndpoint], 'claude-opus', undefined, undefined)).toEqual([
+      claudeEndpoint,
+    ]);
+  });
+
+  it('filters models by label and by id, since a label is additive', () => {
+    const models = ['claude-opus-4-8', 'claude-sonnet-4-6'];
+    expect(filterModels(claudeEndpoint, models, 'Opus 4.8', undefined, undefined)).toEqual([
+      'claude-opus-4-8',
+    ]);
+    expect(filterModels(claudeEndpoint, models, 'opus-4-8', undefined, undefined)).toEqual([
+      'claude-opus-4-8',
+    ]);
+    expect(filterModels(claudeEndpoint, models, 'sonnet', undefined, undefined)).toEqual([
+      'claude-sonnet-4-6',
+    ]);
+  });
+});
+
+describe('getDisplayValue', () => {
+  const localize = ((key: string) => key) as ReturnType<typeof useLocalize>;
+
+  it('shows the label of the selected model', () => {
+    expect(
+      getDisplayValue({
+        localize,
+        mappedEndpoints: [claudeEndpoint],
+        selectedValues: { endpoint: 'Claude', model: 'claude-opus-4-8', modelSpec: '' },
+        modelSpecs: [],
+      }),
+    ).toBe('Opus 4.8');
+  });
+
+  it('shows the id of an unlabelled selected model', () => {
+    expect(
+      getDisplayValue({
+        localize,
+        mappedEndpoints: [claudeEndpoint],
+        selectedValues: { endpoint: 'Claude', model: 'claude-sonnet-4-6', modelSpec: '' },
+        modelSpecs: [],
+      }),
+    ).toBe('claude-sonnet-4-6');
   });
 });

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
@@ -6,6 +6,7 @@ import type { Endpoint } from '~/common';
 import { useFavorites, useLocalize, useIsActiveItem } from '~/hooks';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
+import { getModelName } from '../utils';
 import { cn } from '~/utils';
 
 interface EndpointModelItemProps {
@@ -29,22 +30,15 @@ export function EndpointModelItem({ modelId, endpoint }: EndpointModelItemProps)
   const { ref: itemRef, isActive } = useIsActiveItem<HTMLDivElement>();
 
   let isGlobal = false;
-  let modelName = modelId;
   const avatarUrl = endpoint?.modelIcons?.[modelId ?? ''] || null;
 
-  // Use custom names if available
-  if (endpoint && modelId && isAgentsEndpoint(endpoint.value) && endpoint.agentNames?.[modelId]) {
-    modelName = endpoint.agentNames[modelId];
+  /* Agent or assistant name, or the endpoint's declared label; else the id. */
+  const customName = getModelName(endpoint, modelId);
+  const modelName = customName ?? modelId;
 
+  if (customName != null && isAgentsEndpoint(endpoint?.value)) {
     const modelInfo = endpoint?.models?.find((m) => m.name === modelId);
     isGlobal = modelInfo?.isGlobal ?? false;
-  } else if (
-    endpoint &&
-    modelId &&
-    isAssistantsEndpoint(endpoint.value) &&
-    endpoint.assistantNames?.[modelId]
-  ) {
-    modelName = endpoint.assistantNames[modelId];
   }
 
   const isAgent = isAgentsEndpoint(endpoint.value);

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -1,13 +1,13 @@
 import React, { Fragment } from 'react';
 import { VisuallyHidden } from '@ariakit/react';
 import { CheckCircle2, EarthIcon } from 'lucide-react';
-import { isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
+import { isAgentsEndpoint } from 'librechat-data-provider';
 import type { TModelSpec } from 'librechat-data-provider';
 import type { Endpoint } from '~/common';
 import MarketplaceItem, { marketplaceSearchMatches } from './Marketplace';
+import { getModelName, shouldRenderEndpointOption } from '../utils';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
-import { shouldRenderEndpointOption } from '../utils';
 import SpecDescription from './SpecDescription';
 import SpecIcon from './SpecIcon';
 import { cn } from '~/utils';
@@ -117,20 +117,15 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
             const filteredModels = endpointMatches
               ? models
               : models.filter((model) => {
-                  let modelName = model.name;
-                  if (
-                    isAgentsEndpoint(endpoint.value) &&
-                    endpoint.agentNames &&
-                    endpoint.agentNames[model.name]
-                  ) {
-                    modelName = endpoint.agentNames[model.name];
-                  } else if (
-                    isAssistantsEndpoint(endpoint.value) &&
-                    endpoint.assistantNames &&
-                    endpoint.assistantNames[model.name]
-                  ) {
-                    modelName = endpoint.assistantNames[model.name];
+                  /* A declared label is additive; an agent or assistant name replaces the id. */
+                  const label = endpoint.modelLabels?.[model.name];
+                  if (label != null) {
+                    return (
+                      label.toLowerCase().includes(lowerQuery) ||
+                      model.name.toLowerCase().includes(lowerQuery)
+                    );
                   }
+                  const modelName = getModelName(endpoint, model.name) ?? model.name;
                   return modelName.toLowerCase().includes(lowerQuery);
                 });
 
@@ -158,21 +153,11 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                   const modelId = model.name;
 
                   let isGlobal = false;
-                  let modelName = modelId;
-                  if (
-                    isAgentsEndpoint(endpoint.value) &&
-                    endpoint.agentNames &&
-                    endpoint.agentNames[modelId]
-                  ) {
-                    modelName = endpoint.agentNames[modelId];
+                  const customName = getModelName(endpoint, modelId);
+                  const modelName = customName ?? modelId;
+                  if (customName != null && isAgentsEndpoint(endpoint.value)) {
                     const modelInfo = endpoint?.models?.find((m) => m.name === modelId);
                     isGlobal = modelInfo?.isGlobal ?? false;
-                  } else if (
-                    isAssistantsEndpoint(endpoint.value) &&
-                    endpoint.assistantNames &&
-                    endpoint.assistantNames[modelId]
-                  ) {
-                    modelName = endpoint.assistantNames[modelId];
                   }
 
                   const isModelSelected =

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointModelItem.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointModelItem.test.tsx
@@ -76,6 +76,52 @@ describe('EndpointModelItem', () => {
     expect(menuItem).not.toHaveAttribute('aria-selected');
   });
 
+  it('renders the declared label instead of the model id', () => {
+    mockSelectedValues = { endpoint: 'Claude', model: '', modelSpec: '' };
+    const labelled: Endpoint = {
+      value: 'Claude',
+      label: 'Claude',
+      hasModels: true,
+      models: [{ name: 'claude-opus-4-8' }],
+      modelLabels: { 'claude-opus-4-8': 'Opus 4.8' },
+      icon: null,
+    };
+    render(<EndpointModelItem modelId="claude-opus-4-8" endpoint={labelled} />);
+
+    expect(screen.getByRole('menuitem')).toHaveTextContent('Opus 4.8');
+    expect(screen.getByRole('menuitem')).not.toHaveTextContent('claude-opus-4-8');
+  });
+
+  it('renders the model id when the endpoint labels other models but not this one', () => {
+    mockSelectedValues = { endpoint: 'Claude', model: '', modelSpec: '' };
+    const labelled: Endpoint = {
+      value: 'Claude',
+      label: 'Claude',
+      hasModels: true,
+      models: [{ name: 'claude-opus-4-8' }, { name: 'claude-haiku-4-5' }],
+      modelLabels: { 'claude-opus-4-8': 'Opus 4.8' },
+      icon: null,
+    };
+    render(<EndpointModelItem modelId="claude-haiku-4-5" endpoint={labelled} />);
+
+    expect(screen.getByRole('menuitem')).toHaveTextContent('claude-haiku-4-5');
+  });
+
+  it('selects by model id, not by label', () => {
+    mockSelectedValues = { endpoint: 'Claude', model: 'claude-opus-4-8', modelSpec: '' };
+    const labelled: Endpoint = {
+      value: 'Claude',
+      label: 'Claude',
+      hasModels: true,
+      models: [{ name: 'claude-opus-4-8' }],
+      modelLabels: { 'claude-opus-4-8': 'Opus 4.8' },
+      icon: null,
+    };
+    render(<EndpointModelItem modelId="claude-opus-4-8" endpoint={labelled} />);
+
+    expect(screen.getByRole('menuitem')).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('does NOT render checkmark when endpoint matches but model differs', () => {
     mockSelectedValues = { endpoint: 'anthropic', model: 'claude-sonnet-4-5', modelSpec: '' };
     render(<EndpointModelItem modelId="claude-opus-4-6" endpoint={baseEndpoint} />);

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/SearchResults.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/SearchResults.test.tsx
@@ -77,6 +77,15 @@ const disabledAgentsEndpoint: Endpoint = {
   icon: null,
 };
 
+const labelledEndpoint: Endpoint = {
+  value: 'Claude',
+  label: 'Claude',
+  hasModels: true,
+  models: [{ name: 'claude-opus-4-8' }, { name: 'claude-haiku-4-5' }],
+  modelLabels: { 'claude-opus-4-8': 'Opus 4.8' },
+  icon: null,
+};
+
 describe('SearchResults', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -146,6 +155,38 @@ describe('SearchResults', () => {
     fireEvent.click(item);
     expect(mockNavigate).toHaveBeenCalledWith('/agents');
     expect(mockHandleSelectModel).not.toHaveBeenCalled();
+  });
+
+  it('finds a labelled model by its label and renders the label', () => {
+    mockSelectedValues = { endpoint: '', model: '', modelSpec: '' };
+    render(
+      <SearchResults results={[labelledEndpoint]} localize={localize} searchValue="opus 4.8" />,
+    );
+
+    const items = screen.getAllByRole('menuitem');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent('Opus 4.8');
+  });
+
+  it('still finds a labelled model by its id', () => {
+    mockSelectedValues = { endpoint: '', model: '', modelSpec: '' };
+    render(
+      <SearchResults results={[labelledEndpoint]} localize={localize} searchValue="opus-4-8" />,
+    );
+
+    const items = screen.getAllByRole('menuitem');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent('Opus 4.8');
+  });
+
+  it('selects a labelled model by its id', () => {
+    mockSelectedValues = { endpoint: '', model: '', modelSpec: '' };
+    render(
+      <SearchResults results={[labelledEndpoint]} localize={localize} searchValue="opus 4.8" />,
+    );
+
+    fireEvent.click(screen.getByRole('menuitem'));
+    expect(mockHandleSelectModel).toHaveBeenCalledWith(labelledEndpoint, 'claude-opus-4-8');
   });
 
   it('does not render agents as a selectable endpoint when marketplace and agent rows are unavailable', () => {

--- a/client/src/components/Chat/Menus/Endpoints/utils.ts
+++ b/client/src/components/Chat/Menus/Endpoints/utils.ts
@@ -11,6 +11,35 @@ import type { useLocalize } from '~/hooks';
 import SpecIcon from '~/components/Chat/Menus/Endpoints/components/SpecIcon';
 import { Endpoint, SelectedValues } from '~/common';
 
+/**
+ * The custom display name for a model within an endpoint, or `undefined` when
+ * the model has none and should render its own id.
+ *
+ * Agents and assistants carry names from their records. Every other endpoint may
+ * declare `modelLabels` in `librechat.yaml`, a display-only map from model id to
+ * label — nothing else reads it, and the id stays what is sent upstream.
+ */
+export function getModelName(
+  endpoint: Pick<Endpoint, 'value' | 'agentNames' | 'assistantNames' | 'modelLabels'> | null,
+  modelId: string | null,
+): string | undefined {
+  if (!endpoint || !modelId) {
+    return undefined;
+  }
+
+  let names: Record<string, string> | undefined;
+  if (isAgentsEndpoint(endpoint.value)) {
+    names = endpoint.agentNames;
+  } else if (isAssistantsEndpoint(endpoint.value)) {
+    names = endpoint.assistantNames;
+  } else {
+    names = endpoint.modelLabels;
+  }
+
+  /* An empty name is no name: agentNames holds '' for an unnamed agent. */
+  return names?.[modelId] || undefined;
+}
+
 export function filterItems<
   T extends {
     label: string;
@@ -18,6 +47,7 @@ export function filterItems<
     value?: string;
     hasModels?: boolean;
     models?: Array<{ name: string; isGlobal?: boolean }>;
+    modelLabels?: Record<string, string>;
     searchAliases?: string[];
     showMarketplace?: boolean;
   },
@@ -56,6 +86,12 @@ export function filterItems<
     if (item.models && item.models.length > 0) {
       return item.models.some((modelId) => {
         if (modelId.name.toLowerCase().includes(searchTermLower)) {
+          return true;
+        }
+
+        /* A declared label is additive — the id above stays searchable. */
+        const label = item.modelLabels?.[modelId.name];
+        if (label != null && label.toLowerCase().includes(searchTermLower)) {
           return true;
         }
 
@@ -101,6 +137,12 @@ export function filterModels(
   }
 
   return models.filter((modelId) => {
+    /* A declared label is additive — the id below stays searchable. */
+    const label = endpoint.modelLabels?.[modelId];
+    if (label != null && label.toLowerCase().includes(searchTermLower)) {
+      return true;
+    }
+
     let modelName = modelId;
 
     if (isAgentsEndpoint(endpoint.value) && agentsMap && agentsMap[modelId]) {
@@ -226,7 +268,7 @@ export const getDisplayValue = ({
       return endpoint.assistantNames[selectedValues.model];
     }
 
-    return selectedValues.model;
+    return endpoint.modelLabels?.[selectedValues.model] || selectedValues.model;
   }
 
   if (selectedValues.endpoint) {

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -66,6 +66,16 @@ export default function ModelPanel({
 
   const { data: endpointsConfig = {} } = useGetEndpointsQuery();
 
+  /**
+   * Display-only labels declared by the provider's endpoint. `ControlCombobox`
+   * keeps `value` as the id it hands back, so labelling only changes what the
+   * option and the closed control read.
+   */
+  const modelLabels = useMemo(
+    () => getEndpointField(endpointsConfig, provider, 'modelLabels'),
+    [endpointsConfig, provider],
+  );
+
   const bedrockRegions = useMemo(() => {
     return endpointsConfig?.[provider]?.availableRegions ?? [];
   }, [endpointsConfig, provider]);
@@ -194,6 +204,7 @@ export default function ModelPanel({
                 <>
                   <ControlCombobox
                     selectedValue={field.value || ''}
+                    displayValue={modelLabels?.[field.value || ''] ?? field.value ?? ''}
                     selectPlaceholder={
                       provider
                         ? localize('com_ui_select_model')
@@ -202,7 +213,7 @@ export default function ModelPanel({
                     searchPlaceholder={localize('com_ui_select_model')}
                     setValue={field.onChange}
                     items={models.map((model) => ({
-                      label: model,
+                      label: modelLabels?.[model] ?? model,
                       value: model,
                     }))}
                     disabled={!provider}

--- a/client/src/hooks/Endpoint/useEndpoints.ts
+++ b/client/src/hooks/Endpoint/useEndpoints.ts
@@ -89,6 +89,7 @@ export const useEndpoints = ({
       const iconKey = getIconKey({ endpoint: ep, endpointsConfig, endpointType });
       const Icon = icons[iconKey];
       const endpointIconURL = getEndpointField(endpointsConfig, ep, 'iconURL');
+      const modelLabels = getEndpointField(endpointsConfig, ep, 'modelLabels');
       const hasModels =
         (ep === EModelEndpoint.agents && ((agents?.length ?? 0) > 0 || showAgentMarketplace)) ||
         (ep === EModelEndpoint.assistants && assistants?.length > 0) ||
@@ -105,6 +106,7 @@ export const useEndpoints = ({
         value: ep,
         label: alternateName[ep] || ep,
         hasModels,
+        modelLabels,
         icon: Icon
           ? React.createElement(Icon, {
               size: 20,

--- a/packages/api/src/endpoints/config/availability.spec.ts
+++ b/packages/api/src/endpoints/config/availability.spec.ts
@@ -1,0 +1,230 @@
+import { EModelEndpoint } from 'librechat-data-provider';
+import type { ServerRequest } from '~/types';
+import { declaredModelNames, hasModelSource } from './availability';
+import { createLoadConfigModels } from './models';
+
+const GATEWAY = {
+  baseURL: 'https://gateway.example.com/v1',
+  apiKey: 'gateway-key',
+};
+
+/** One gateway, several endpoints over it — the shape `filter` exists for. */
+const buildAppConfig = (endpoints: Record<string, unknown>[]) => ({
+  endpoints: {
+    [EModelEndpoint.custom]: endpoints.map((endpoint) => ({ ...GATEWAY, ...endpoint })),
+  },
+});
+
+const buildRequest = () =>
+  ({ user: { id: 'user-1' }, config: undefined }) as unknown as ServerRequest;
+
+const load = (endpoints: Record<string, unknown>[], fetchModels: jest.Mock) =>
+  createLoadConfigModels({
+    getAppConfig: jest.fn().mockResolvedValue(buildAppConfig(endpoints)),
+    getUserKeyValues: jest.fn().mockResolvedValue(null),
+    fetchModels,
+  })(buildRequest());
+
+describe('declaredModelNames', () => {
+  it('normalizes both string and object model entries', () => {
+    expect(
+      declaredModelNames({
+        models: { default: ['a', { name: 'b', description: 'B' }] },
+      } as never),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('treats a missing or malformed list as no declaration', () => {
+    expect(declaredModelNames(undefined)).toEqual([]);
+    expect(declaredModelNames({ models: { default: [] } } as never)).toEqual([]);
+    expect(declaredModelNames({ models: {} } as never)).toEqual([]);
+  });
+});
+
+describe('hasModelSource', () => {
+  it('is true for a fetching endpoint even with nothing declared', () => {
+    expect(hasModelSource({ models: { default: [], fetch: true } } as never)).toBe(true);
+  });
+
+  it('is true for a declared list with no fetch', () => {
+    expect(hasModelSource({ models: { default: ['a'] } } as never)).toBe(true);
+  });
+
+  it('is false for an empty declaration with no fetch, where a truthiness test would pass', () => {
+    const endpoint = { models: { default: [] } } as never;
+    expect(Boolean((endpoint as { models: { default: string[] } }).models.default)).toBe(true);
+    expect(hasModelSource(endpoint)).toBe(false);
+  });
+});
+
+describe('loadConfigModels – declared ∩ fetched', () => {
+  let fetchModels: jest.Mock;
+
+  beforeEach(() => {
+    fetchModels = jest.fn();
+  });
+
+  it('serves only declared models the gateway actually has, in declared order', async () => {
+    fetchModels.mockResolvedValue(['gpt-5.6', 'claude-sonnet-5', 'cohere-rerank']);
+
+    const result = await load(
+      [
+        {
+          name: 'Claude',
+          models: { default: ['claude-opus-5', 'claude-sonnet-5'], fetch: true, filter: true },
+        },
+      ],
+      fetchModels,
+    );
+
+    expect(result.Claude).toEqual(['claude-sonnet-5']);
+  });
+
+  it('gives endpoints over one gateway their own slice from a single fetch', async () => {
+    fetchModels.mockResolvedValue(['claude-sonnet-5', 'gpt-5.6', 'gemini-3.7-flash']);
+
+    const result = await load(
+      [
+        { name: 'Claude', models: { default: ['claude-sonnet-5'], fetch: true, filter: true } },
+        { name: 'OpenAI', models: { default: ['gpt-5.6'], fetch: true, filter: true } },
+      ],
+      fetchModels,
+    );
+
+    expect(result.Claude).toEqual(['claude-sonnet-5']);
+    expect(result.OpenAI).toEqual(['gpt-5.6']);
+    /* Same baseURL, apiKey and headers: one coalesced fetch serves both. */
+    expect(fetchModels).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves to nothing when the gateway answers with an empty catalog', async () => {
+    fetchModels.mockResolvedValue([]);
+
+    const result = await load(
+      [{ name: 'Claude', models: { default: ['claude-sonnet-5'], fetch: true, filter: true } }],
+      fetchModels,
+    );
+
+    expect(result.Claude).toEqual([]);
+  });
+
+  it('does not need an authorization header to fail closed on an empty answer', async () => {
+    fetchModels.mockResolvedValue([]);
+
+    const result = await load(
+      [
+        {
+          name: 'Claude',
+          headers: { 'x-user-email': '{{LIBRECHAT_USER_EMAIL}}' },
+          models: { default: ['claude-sonnet-5'], fetch: true, filter: true },
+        },
+      ],
+      fetchModels,
+    );
+
+    expect(result.Claude).toEqual([]);
+  });
+
+  it('falls back to the declared list when the fetch fails outright', async () => {
+    fetchModels.mockRejectedValue(new Error('gateway unreachable'));
+
+    const result = await load(
+      [
+        {
+          name: 'Claude',
+          models: { default: ['claude-opus-5', 'claude-sonnet-5'], fetch: true, filter: true },
+        },
+      ],
+      fetchModels,
+    );
+
+    expect(result.Claude).toEqual(['claude-opus-5', 'claude-sonnet-5']);
+  });
+
+  it('fails open on a failed fetch even when the endpoint sends an authorization header', async () => {
+    fetchModels.mockRejectedValue(new Error('gateway unreachable'));
+
+    const result = await load(
+      [
+        {
+          name: 'Claude',
+          headers: { authorization: 'Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}' },
+          models: { default: ['claude-sonnet-5'], fetch: true, filter: true },
+        },
+      ],
+      fetchModels,
+    );
+
+    expect(result.Claude).toEqual(['claude-sonnet-5']);
+  });
+
+  it('leaves the declared list alone when there is no fetch to intersect', async () => {
+    const result = await load(
+      [{ name: 'Claude', models: { default: ['claude-sonnet-5'], filter: true } }],
+      fetchModels,
+    );
+
+    expect(result.Claude).toEqual(['claude-sonnet-5']);
+    expect(fetchModels).not.toHaveBeenCalled();
+  });
+
+  it('skips an endpoint that declares nothing and fetches nothing', async () => {
+    const result = await load(
+      [
+        { name: 'Other', models: { default: [], filter: true } },
+        { name: 'Claude', models: { default: ['claude-sonnet-5'] } },
+      ],
+      fetchModels,
+    );
+
+    expect(result).not.toHaveProperty('Other');
+    expect(result.Claude).toEqual(['claude-sonnet-5']);
+  });
+});
+
+describe('loadConfigModels – endpoints without `filter` are unchanged', () => {
+  let fetchModels: jest.Mock;
+
+  beforeEach(() => {
+    fetchModels = jest.fn();
+  });
+
+  it('replaces the declared list with the fetched catalog', async () => {
+    fetchModels.mockResolvedValue(['gpt-5.6', 'cohere-rerank']);
+
+    const result = await load(
+      [{ name: 'LiteLLM', models: { default: ['stale-name'], fetch: true } }],
+      fetchModels,
+    );
+
+    expect(result.LiteLLM).toEqual(['gpt-5.6', 'cohere-rerank']);
+  });
+
+  it('keeps the OIDC empty-answer behaviour: authorization header yields nothing', async () => {
+    fetchModels.mockResolvedValue([]);
+
+    const result = await load(
+      [
+        {
+          name: 'LiteLLM',
+          headers: { Authorization: 'Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}' },
+          models: { default: ['claude-sonnet-5'], fetch: true },
+        },
+      ],
+      fetchModels,
+    );
+
+    expect(result.LiteLLM).toEqual([]);
+  });
+
+  it('keeps the fallback to declared models on an empty answer without that header', async () => {
+    fetchModels.mockResolvedValue([]);
+
+    const result = await load(
+      [{ name: 'LiteLLM', models: { default: ['claude-sonnet-5'], fetch: true } }],
+      fetchModels,
+    );
+
+    expect(result.LiteLLM).toEqual(['claude-sonnet-5']);
+  });
+});

--- a/packages/api/src/endpoints/config/availability.ts
+++ b/packages/api/src/endpoints/config/availability.ts
@@ -1,0 +1,44 @@
+import type { TEndpoint } from 'librechat-data-provider';
+
+/**
+ * Model availability helpers for custom endpoints.
+ *
+ * Kept as a leaf module — it imports nothing from `~` — so both the models
+ * loader and the endpoints loader can share one definition of "can this
+ * endpoint serve models at all" without a cycle between them. The two used to
+ * carry copies of that predicate, which is how they drifted.
+ */
+
+/**
+ * The `models` block is all these helpers read, and both the validated
+ * (`TEndpoint`) and raw-config (`Partial<TEndpoint>`) shapes satisfy this.
+ */
+export type EndpointModelsSource = { models?: TEndpoint['models'] };
+
+/**
+ * `models.default` normalized to plain names. Entries may be bare strings or
+ * `{ name }` objects; both forms mean the same model.
+ */
+export function declaredModelNames(endpoint?: EndpointModelsSource | null): string[] {
+  const declared = endpoint?.models?.default;
+  if (!Array.isArray(declared)) {
+    return [];
+  }
+  return declared.map((model) => (typeof model === 'string' ? model : model.name));
+}
+
+/**
+ * Whether an endpoint has any source of models: a live fetch, or a non-empty
+ * declared list.
+ *
+ * The length test is load-bearing. `models.default` may legitimately be empty —
+ * that is how a base configuration ships an endpoint template for a deployment
+ * to fill in — and `[]` is truthy, so a bare truthiness check would admit an
+ * endpoint that can never produce a model and leave it advertised but unusable.
+ */
+export function hasModelSource(endpoint?: EndpointModelsSource | null): boolean {
+  if (!endpoint?.models) {
+    return false;
+  }
+  return Boolean(endpoint.models.fetch) || declaredModelNames(endpoint).length > 0;
+}

--- a/packages/api/src/endpoints/config/endpoints.spec.ts
+++ b/packages/api/src/endpoints/config/endpoints.spec.ts
@@ -389,6 +389,95 @@ describe('createEndpointsConfigService', () => {
   });
 });
 
+describe('withholding custom endpoints with no available models', () => {
+  const customEndpoints = {
+    Claude: { userProvide: false },
+    Other: { userProvide: false },
+  };
+
+  function depsWithModels(
+    modelsConfig: Record<string, string[]> | Error,
+  ): EndpointsConfigDeps & { getModelsConfig: jest.Mock } {
+    const getModelsConfig = jest.fn(() =>
+      modelsConfig instanceof Error ? Promise.reject(modelsConfig) : Promise.resolve(modelsConfig),
+    );
+    return {
+      ...createMockDeps({
+        loadCustomEndpointsConfig: jest.fn().mockReturnValue(customEndpoints),
+      }),
+      getModelsConfig,
+    } as EndpointsConfigDeps & { getModelsConfig: jest.Mock };
+  }
+
+  it('drops an endpoint whose model list is empty', async () => {
+    const deps = depsWithModels({ Claude: ['claude-sonnet-5'], Other: [] });
+    const { getEndpointsConfig } = createEndpointsConfigService(deps);
+    const result = await getEndpointsConfig(fakeReq());
+
+    expect(result?.Claude).toBeDefined();
+    expect(result).not.toHaveProperty('Other');
+  });
+
+  it('keeps every endpoint that has at least one model', async () => {
+    const deps = depsWithModels({ Claude: ['claude-sonnet-5'], Other: ['agentcore-thing'] });
+    const { getEndpointsConfig } = createEndpointsConfigService(deps);
+    const result = await getEndpointsConfig(fakeReq());
+
+    expect(result?.Claude).toBeDefined();
+    expect(result?.Other).toBeDefined();
+  });
+
+  it('never withholds built-in endpoints, whatever the models config says', async () => {
+    const deps = depsWithModels({
+      Claude: [],
+      Other: [],
+      [EModelEndpoint.openAI]: [],
+    });
+    const { getEndpointsConfig } = createEndpointsConfigService(deps);
+    const result = await getEndpointsConfig(fakeReq());
+
+    expect(result?.[EModelEndpoint.openAI]).toBeDefined();
+    expect(result).not.toHaveProperty('Claude');
+    expect(result).not.toHaveProperty('Other');
+  });
+
+  it('fails open when the models config cannot be resolved', async () => {
+    const deps = depsWithModels(new Error('gateway unreachable'));
+    const { getEndpointsConfig } = createEndpointsConfigService(deps);
+    const result = await getEndpointsConfig(fakeReq());
+
+    expect(result?.Claude).toBeDefined();
+    expect(result?.Other).toBeDefined();
+  });
+
+  it('fails open for an endpoint the models config has no entry for', async () => {
+    const deps = depsWithModels({ Claude: ['claude-sonnet-5'] });
+    const { getEndpointsConfig } = createEndpointsConfigService(deps);
+    const result = await getEndpointsConfig(fakeReq());
+
+    expect(result?.Other).toBeDefined();
+  });
+
+  it('leaves every endpoint in place when no models resolver is supplied', async () => {
+    const deps = createMockDeps({
+      loadCustomEndpointsConfig: jest.fn().mockReturnValue(customEndpoints),
+    });
+    const { getEndpointsConfig } = createEndpointsConfigService(deps);
+    const result = await getEndpointsConfig(fakeReq());
+
+    expect(result?.Claude).toBeDefined();
+    expect(result?.Other).toBeDefined();
+  });
+
+  it('resolves the models config once per endpoints-config call', async () => {
+    const deps = depsWithModels({ Claude: ['claude-sonnet-5'], Other: [] });
+    const { getEndpointsConfig } = createEndpointsConfigService(deps);
+    await getEndpointsConfig(fakeReq());
+
+    expect(deps.getModelsConfig).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('defaultAgentCapabilities', () => {
   it('includes AgentCapabilities.skills so skills are enabled by default', () => {
     expect(defaultAgentCapabilities).toContain(AgentCapabilities.skills);

--- a/packages/api/src/endpoints/config/endpoints.spec.ts
+++ b/packages/api/src/endpoints/config/endpoints.spec.ts
@@ -418,6 +418,21 @@ describe('withholding custom endpoints with no available models', () => {
     expect(result).not.toHaveProperty('Other');
   });
 
+  it('never withholds a user-provided endpoint — its empty list reflects a fixable key', async () => {
+    const deps = depsWithModels({ Anthropic: [], BYOK: [], ByURL: [] });
+    deps.loadCustomEndpointsConfig = jest.fn().mockReturnValue({
+      Anthropic: { userProvide: false },
+      BYOK: { userProvide: true },
+      ByURL: { userProvide: false, userProvideURL: true },
+    });
+    const { getEndpointsConfig } = createEndpointsConfigService(deps);
+    const result = await getEndpointsConfig(fakeReq(), { withholdEmpty: true });
+
+    expect(result).not.toHaveProperty('Anthropic');
+    expect(result?.BYOK).toBeDefined();
+    expect(result?.ByURL).toBeDefined();
+  });
+
   it('keeps every endpoint that has at least one model', async () => {
     const deps = depsWithModels({ Anthropic: ['claude-sonnet-5'], Other: ['agentcore-thing'] });
     const { getEndpointsConfig } = createEndpointsConfigService(deps);

--- a/packages/api/src/endpoints/config/endpoints.spec.ts
+++ b/packages/api/src/endpoints/config/endpoints.spec.ts
@@ -391,7 +391,7 @@ describe('createEndpointsConfigService', () => {
 
 describe('withholding custom endpoints with no available models', () => {
   const customEndpoints = {
-    Claude: { userProvide: false },
+    Anthropic: { userProvide: false },
     Other: { userProvide: false },
   };
 
@@ -410,50 +410,50 @@ describe('withholding custom endpoints with no available models', () => {
   }
 
   it('drops an endpoint whose model list is empty', async () => {
-    const deps = depsWithModels({ Claude: ['claude-sonnet-5'], Other: [] });
+    const deps = depsWithModels({ Anthropic: ['claude-sonnet-5'], Other: [] });
     const { getEndpointsConfig } = createEndpointsConfigService(deps);
-    const result = await getEndpointsConfig(fakeReq());
+    const result = await getEndpointsConfig(fakeReq(), { withholdEmpty: true });
 
-    expect(result?.Claude).toBeDefined();
+    expect(result?.Anthropic).toBeDefined();
     expect(result).not.toHaveProperty('Other');
   });
 
   it('keeps every endpoint that has at least one model', async () => {
-    const deps = depsWithModels({ Claude: ['claude-sonnet-5'], Other: ['agentcore-thing'] });
+    const deps = depsWithModels({ Anthropic: ['claude-sonnet-5'], Other: ['agentcore-thing'] });
     const { getEndpointsConfig } = createEndpointsConfigService(deps);
-    const result = await getEndpointsConfig(fakeReq());
+    const result = await getEndpointsConfig(fakeReq(), { withholdEmpty: true });
 
-    expect(result?.Claude).toBeDefined();
+    expect(result?.Anthropic).toBeDefined();
     expect(result?.Other).toBeDefined();
   });
 
   it('never withholds built-in endpoints, whatever the models config says', async () => {
     const deps = depsWithModels({
-      Claude: [],
+      Anthropic: [],
       Other: [],
       [EModelEndpoint.openAI]: [],
     });
     const { getEndpointsConfig } = createEndpointsConfigService(deps);
-    const result = await getEndpointsConfig(fakeReq());
+    const result = await getEndpointsConfig(fakeReq(), { withholdEmpty: true });
 
     expect(result?.[EModelEndpoint.openAI]).toBeDefined();
-    expect(result).not.toHaveProperty('Claude');
+    expect(result).not.toHaveProperty('Anthropic');
     expect(result).not.toHaveProperty('Other');
   });
 
   it('fails open when the models config cannot be resolved', async () => {
     const deps = depsWithModels(new Error('gateway unreachable'));
     const { getEndpointsConfig } = createEndpointsConfigService(deps);
-    const result = await getEndpointsConfig(fakeReq());
+    const result = await getEndpointsConfig(fakeReq(), { withholdEmpty: true });
 
-    expect(result?.Claude).toBeDefined();
+    expect(result?.Anthropic).toBeDefined();
     expect(result?.Other).toBeDefined();
   });
 
   it('fails open for an endpoint the models config has no entry for', async () => {
-    const deps = depsWithModels({ Claude: ['claude-sonnet-5'] });
+    const deps = depsWithModels({ Anthropic: ['claude-sonnet-5'] });
     const { getEndpointsConfig } = createEndpointsConfigService(deps);
-    const result = await getEndpointsConfig(fakeReq());
+    const result = await getEndpointsConfig(fakeReq(), { withholdEmpty: true });
 
     expect(result?.Other).toBeDefined();
   });
@@ -463,18 +463,39 @@ describe('withholding custom endpoints with no available models', () => {
       loadCustomEndpointsConfig: jest.fn().mockReturnValue(customEndpoints),
     });
     const { getEndpointsConfig } = createEndpointsConfigService(deps);
-    const result = await getEndpointsConfig(fakeReq());
+    const result = await getEndpointsConfig(fakeReq(), { withholdEmpty: true });
 
-    expect(result?.Claude).toBeDefined();
+    expect(result?.Anthropic).toBeDefined();
     expect(result?.Other).toBeDefined();
   });
 
   it('resolves the models config once per endpoints-config call', async () => {
-    const deps = depsWithModels({ Claude: ['claude-sonnet-5'], Other: [] });
+    const deps = depsWithModels({ Anthropic: ['claude-sonnet-5'], Other: [] });
     const { getEndpointsConfig } = createEndpointsConfigService(deps);
-    await getEndpointsConfig(fakeReq());
+    await getEndpointsConfig(fakeReq(), { withholdEmpty: true });
 
     expect(deps.getModelsConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('withholds nothing unless the caller asks, and does not resolve models to find out', async () => {
+    const deps = depsWithModels({ Anthropic: ['claude-sonnet-5'], Other: [] });
+    const { getEndpointsConfig } = createEndpointsConfigService(deps);
+    const result = await getEndpointsConfig(fakeReq());
+
+    /* The request path reads `defaultParamsEndpoint` and `userProvide` off these
+       keys, so a caller that has not asked for pruning must see all of them —
+       and must not pay a catalog fetch to be told so. */
+    expect(result?.Anthropic).toBeDefined();
+    expect(result?.Other).toBeDefined();
+    expect(deps.getModelsConfig).not.toHaveBeenCalled();
+  });
+
+  it('does not resolve models for a capability check', async () => {
+    const deps = depsWithModels({ Anthropic: [], Other: [] });
+    const { checkCapability } = createEndpointsConfigService(deps);
+    await checkCapability(fakeReq(), AgentCapabilities.execute_code);
+
+    expect(deps.getModelsConfig).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/endpoints/config/endpoints.ts
+++ b/packages/api/src/endpoints/config/endpoints.ts
@@ -36,8 +36,24 @@ export interface EndpointsConfigDeps {
   getModelsConfig?: (req: ServerRequest) => Promise<TModelsConfig>;
 }
 
+export interface GetEndpointsConfigOptions {
+  /**
+   * Drop custom endpoints that can serve nothing for this request.
+   *
+   * Off by default, and deliberately: it costs a models resolution, which for a
+   * user-scoped endpoint means a live catalog fetch, and it removes keys that
+   * callers on the request path read for reasons unrelated to presentation —
+   * `defaultParamsEndpoint`, `userProvide`. Only a caller answering "what may
+   * this user be offered" wants it.
+   */
+  withholdEmpty?: boolean;
+}
+
 export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
-  getEndpointsConfig: (req: ServerRequest) => Promise<TEndpointsConfig>;
+  getEndpointsConfig: (
+    req: ServerRequest,
+    options?: GetEndpointsConfigOptions,
+  ) => Promise<TEndpointsConfig>;
   checkCapability: (req: ServerRequest, capability: AgentCapabilities) => Promise<boolean>;
 } {
   const {
@@ -47,7 +63,10 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
     getModelsConfig,
   } = deps;
 
-  async function getEndpointsConfig(req: ServerRequest): Promise<TEndpointsConfig> {
+  async function getEndpointsConfig(
+    req: ServerRequest,
+    options: GetEndpointsConfigOptions = {},
+  ): Promise<TEndpointsConfig> {
     const appConfig =
       req.config ??
       (await getAppConfig({
@@ -137,7 +156,9 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
       };
     }
 
-    await withholdEmptyCustomEndpoints(req, mergedConfig, customEndpointsConfig);
+    if (options.withholdEmpty) {
+      await withholdEmptyCustomEndpoints(req, mergedConfig, customEndpointsConfig);
+    }
 
     return orderEndpointsConfig(mergedConfig as TEndpointsConfig);
   }
@@ -153,6 +174,8 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
    * Fails open. Only an explicit empty list withholds an endpoint; a models
    * loader that throws, or that has no entry for an endpoint at all, leaves
    * every declared endpoint in place.
+   *
+   * Reached only when the caller asks for it — see `withholdEmpty`.
    */
   async function withholdEmptyCustomEndpoints(
     req: ServerRequest,

--- a/packages/api/src/endpoints/config/endpoints.ts
+++ b/packages/api/src/endpoints/config/endpoints.ts
@@ -1,3 +1,4 @@
+import { logger } from '@librechat/data-schemas';
 import {
   AuthType,
   EModelEndpoint,
@@ -5,7 +6,12 @@ import {
   orderEndpointsConfig,
   defaultAgentCapabilities,
 } from 'librechat-data-provider';
-import type { AgentCapabilities, TEndpointsConfig, TConfig } from 'librechat-data-provider';
+import type {
+  AgentCapabilities,
+  TEndpointsConfig,
+  TConfig,
+  TModelsConfig,
+} from 'librechat-data-provider';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { ServerRequest, TCustomEndpointsConfig } from '~/types';
 import { loadCustomEndpointsConfig as defaultLoadCustomEndpoints } from '~/endpoints/custom';
@@ -22,6 +28,12 @@ export interface EndpointsConfigDeps {
   }) => Promise<AppConfig>;
   loadDefaultEndpointsConfig: (appConfig: AppConfig) => Promise<DefaultEndpointsResult>;
   loadCustomEndpointsConfig?: (custom: unknown) => TCustomEndpointsConfig | undefined;
+  /**
+   * Resolves the models available to this request. Supplied so a custom
+   * endpoint with nothing to serve can be withheld from the endpoints config
+   * entirely; omit it to leave every declared endpoint in place.
+   */
+  getModelsConfig?: (req: ServerRequest) => Promise<TModelsConfig>;
 }
 
 export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
@@ -32,6 +44,7 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
     getAppConfig,
     loadDefaultEndpointsConfig,
     loadCustomEndpointsConfig = defaultLoadCustomEndpoints,
+    getModelsConfig,
   } = deps;
 
   async function getEndpointsConfig(req: ServerRequest): Promise<TEndpointsConfig> {
@@ -124,7 +137,57 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
       };
     }
 
+    await withholdEmptyCustomEndpoints(req, mergedConfig, customEndpointsConfig);
+
     return orderEndpointsConfig(mergedConfig as TEndpointsConfig);
+  }
+
+  /**
+   * Removes custom endpoints that can serve nothing for this request.
+   *
+   * An endpoint with an empty model list is not a usable endpoint: it renders
+   * as an empty picker entry, and the agent builder offers it as a provider
+   * with no model to pick. Built-in endpoints are left alone — their model
+   * lists come from elsewhere and are not per-request.
+   *
+   * Fails open. Only an explicit empty list withholds an endpoint; a models
+   * loader that throws, or that has no entry for an endpoint at all, leaves
+   * every declared endpoint in place.
+   */
+  async function withholdEmptyCustomEndpoints(
+    req: ServerRequest,
+    mergedConfig: MutableEndpointsConfig,
+    customEndpointsConfig: TCustomEndpointsConfig | undefined,
+  ): Promise<void> {
+    if (getModelsConfig == null || customEndpointsConfig == null) {
+      return;
+    }
+
+    const customNames = Object.keys(customEndpointsConfig);
+    if (customNames.length === 0) {
+      return;
+    }
+
+    let modelsConfig: TModelsConfig;
+    try {
+      modelsConfig = await getModelsConfig(req);
+    } catch (error) {
+      logger.error(
+        '[getEndpointsConfig] Could not resolve available models; leaving every declared endpoint in place',
+        error,
+      );
+      return;
+    }
+
+    for (const name of customNames) {
+      const available = modelsConfig?.[name];
+      if (Array.isArray(available) && available.length === 0) {
+        logger.debug(
+          `[getEndpointsConfig] Withholding custom endpoint "${name}": no models available for this request`,
+        );
+        delete mergedConfig[name];
+      }
+    }
   }
 
   async function checkCapability(

--- a/packages/api/src/endpoints/config/endpoints.ts
+++ b/packages/api/src/endpoints/config/endpoints.ts
@@ -203,6 +203,16 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
     }
 
     for (const name of customNames) {
+      /* A user-provided endpoint's model list reflects the user's stored key —
+         missing, expired, or granted nothing — and the picker entry is the only
+         way to set or fix that key. Withholding it would lock the user out, so
+         it stays visible even when empty; `validateModel` exempts it the same
+         way. */
+      const config = customEndpointsConfig[name];
+      if (config?.userProvide || config?.userProvideURL) {
+        continue;
+      }
+
       const available = modelsConfig?.[name];
       if (Array.isArray(available) && available.length === 0) {
         logger.debug(

--- a/packages/api/src/endpoints/config/index.ts
+++ b/packages/api/src/endpoints/config/index.ts
@@ -1,5 +1,7 @@
+export { declaredModelNames, hasModelSource } from './availability';
 export { createEndpointsConfigService } from './endpoints';
 export { createLoadConfigModels } from './models';
 export * from './providers';
 export type { EndpointsConfigDeps } from './endpoints';
 export type { LoadConfigModelsDeps } from './models';
+export type { EndpointModelsSource } from './availability';

--- a/packages/api/src/endpoints/config/models.ts
+++ b/packages/api/src/endpoints/config/models.ts
@@ -10,6 +10,7 @@ import type { TModelsConfig, TEndpoint } from 'librechat-data-provider';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { ServerRequest, GetUserKeyValuesFunction, UserKeyValues } from '~/types';
 import type { FetchModelsParams } from '~/endpoints/models';
+import { declaredModelNames, hasModelSource } from '~/endpoints/config/availability';
 import { fetchModels as defaultFetchModels } from '~/endpoints/models';
 import { getTokenConfigKey } from '~/endpoints/custom/initialize';
 import { validateEndpointURL } from '~/auth';
@@ -101,11 +102,7 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
 
     const customEndpoints = (appConfig.endpoints[EModelEndpoint.custom] as TEndpoint[]).filter(
       (endpoint) =>
-        endpoint.baseURL &&
-        endpoint.apiKey &&
-        endpoint.name &&
-        endpoint.models &&
-        (endpoint.models.fetch || endpoint.models.default),
+        endpoint.baseURL && endpoint.apiKey && endpoint.name && hasModelSource(endpoint),
     );
 
     const fetchPromisesMap: Record<string, Promise<string[]>> = {};
@@ -262,11 +259,10 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
         }
       }
 
-      if (Array.isArray(models?.default)) {
-        modelsConfig[name] = models.default.map((model) =>
-          typeof model === 'string' ? model : model.name,
-        );
-      }
+      /** Nothing is fetched for this endpoint, so there is nothing to
+       *  intersect: `filter` is inert and the declared list is the whole
+       *  catalog the endpoint can offer. */
+      modelsConfig[name] = declaredModelNames(endpoint);
     }
 
     const settledResults = await Promise.allSettled(Object.values(fetchPromisesMap));
@@ -278,21 +274,45 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
       if (settled.status === 'rejected') {
         logger.warn(`[loadConfigModels] Model fetch failed for "${currentKey}":`, settled.reason);
       }
-      const modelData = settled.status === 'fulfilled' ? settled.value : [];
+      /** `null` means the fetch never answered. Kept distinct from an answer of
+       *  `[]`: one is a broken pipe, the other is the gateway stating that this
+       *  identity has no models, and they must not resolve the same way. */
+      const fetchedModels = settled.status === 'fulfilled' ? (settled.value ?? []) : null;
       const associatedNames = uniqueKeyToEndpointsMap[currentKey];
 
       for (const name of associatedNames) {
         const endpoint = endpointsMap[name];
+        const declared = declaredModelNames(endpoint);
+
+        if (fetchedModels == null) {
+          /** Fail open on transport failure, for every endpoint. An empty list
+           *  can now remove an endpoint outright, so treating an unreachable
+           *  gateway as an authoritative empty would delete endpoints during a
+           *  blip and invalidate stored agents that name them. This is the one
+           *  path where an endpoint sending an `authorization` header no longer
+           *  matches its previous behaviour: it used to collapse to `[]` here,
+           *  because a rejected fetch was flattened into an empty answer before
+           *  that check ran. */
+          modelsConfig[name] = declared;
+          continue;
+        }
+
+        if (endpoint.models?.filter) {
+          /** Declared order is preserved — the list is authored for display.
+           *  An empty answer intersects to nothing, which is the same
+           *  fail-closed outcome the `authorization` branch below hard-codes
+           *  for unfiltered endpoints, reached without inspecting headers. */
+          modelsConfig[name] = declared.filter((model) => fetchedModels.includes(model));
+          continue;
+        }
+
         const usesOidcAuth = hasAuthorizationHeader(endpoint.headers);
-        if (!modelData?.length && usesOidcAuth) {
+        if (!fetchedModels.length && usesOidcAuth) {
           modelsConfig[name] = [];
-        } else if (!modelData?.length) {
-          const defaults = (endpoint.models?.default ?? []).map((m) =>
-            typeof m === 'string' ? m : m.name,
-          );
-          modelsConfig[name] = defaults;
+        } else if (!fetchedModels.length) {
+          modelsConfig[name] = declared;
         } else {
-          modelsConfig[name] = modelData;
+          modelsConfig[name] = fetchedModels;
         }
       }
 

--- a/packages/api/src/endpoints/config/models.ts
+++ b/packages/api/src/endpoints/config/models.ts
@@ -12,6 +12,14 @@ import type { ServerRequest, GetUserKeyValuesFunction, UserKeyValues } from '~/t
 import type { FetchModelsParams } from '~/endpoints/models';
 import { declaredModelNames, hasModelSource } from '~/endpoints/config/availability';
 import { fetchModels as defaultFetchModels } from '~/endpoints/models';
+
+/**
+ * Tighter than `fetchModels`' own ceiling because every caller of this loader
+ * degrades gracefully: a fetch that does not answer falls back to the declared
+ * list, and the gateway rejects a model the user lacks regardless. Waiting
+ * longer buys a more accurate list at the cost of a blank picker.
+ */
+const CATALOG_FETCH_TIMEOUT_MS = 2000;
 import { getTokenConfigKey } from '~/endpoints/custom/initialize';
 import { validateEndpointURL } from '~/auth';
 import { tokenConfigCache } from '~/cache';
@@ -206,6 +214,7 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
             direct: endpoint.directEndpoint,
             userIdQuery: models.userIdQuery,
             tokenKey,
+            timeoutMs: CATALOG_FETCH_TIMEOUT_MS,
           });
         }
         uniqueKeyToEndpointsMap[uniqueKey] = uniqueKeyToEndpointsMap[uniqueKey] || [];
@@ -251,6 +260,7 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
                 skipCache: true,
                 /** Fetched with the user's key/URL — always user-scoped */
                 tokenKey: getTokenConfigKey(endpoint, name, req.user?.id ?? '', tenantId),
+                timeoutMs: CATALOG_FETCH_TIMEOUT_MS,
               });
             })();
           uniqueKeyToEndpointsMap[userFetchKey] = uniqueKeyToEndpointsMap[userFetchKey] || [];

--- a/packages/api/src/endpoints/config/models.ts
+++ b/packages/api/src/endpoints/config/models.ts
@@ -12,14 +12,6 @@ import type { ServerRequest, GetUserKeyValuesFunction, UserKeyValues } from '~/t
 import type { FetchModelsParams } from '~/endpoints/models';
 import { declaredModelNames, hasModelSource } from '~/endpoints/config/availability';
 import { fetchModels as defaultFetchModels } from '~/endpoints/models';
-
-/**
- * Tighter than `fetchModels`' own ceiling because every caller of this loader
- * degrades gracefully: a fetch that does not answer falls back to the declared
- * list, and the gateway rejects a model the user lacks regardless. Waiting
- * longer buys a more accurate list at the cost of a blank picker.
- */
-const CATALOG_FETCH_TIMEOUT_MS = 2000;
 import { getTokenConfigKey } from '~/endpoints/custom/initialize';
 import { validateEndpointURL } from '~/auth';
 import { tokenConfigCache } from '~/cache';
@@ -214,7 +206,6 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
             direct: endpoint.directEndpoint,
             userIdQuery: models.userIdQuery,
             tokenKey,
-            timeoutMs: CATALOG_FETCH_TIMEOUT_MS,
           });
         }
         uniqueKeyToEndpointsMap[uniqueKey] = uniqueKeyToEndpointsMap[uniqueKey] || [];
@@ -260,7 +251,6 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
                 skipCache: true,
                 /** Fetched with the user's key/URL — always user-scoped */
                 tokenKey: getTokenConfigKey(endpoint, name, req.user?.id ?? '', tenantId),
-                timeoutMs: CATALOG_FETCH_TIMEOUT_MS,
               });
             })();
           uniqueKeyToEndpointsMap[userFetchKey] = uniqueKeyToEndpointsMap[userFetchKey] || [];

--- a/packages/api/src/endpoints/config/models.ts
+++ b/packages/api/src/endpoints/config/models.ts
@@ -278,6 +278,9 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
        *  `[]`: one is a broken pipe, the other is the gateway stating that this
        *  identity has no models, and they must not resolve the same way. */
       const fetchedModels = settled.status === 'fulfilled' ? (settled.value ?? []) : null;
+      /** Built lazily, at most once per fetch result, and shared by every
+       *  endpoint intersecting against it. */
+      let fetchedSet: Set<string> | null = null;
       const associatedNames = uniqueKeyToEndpointsMap[currentKey];
 
       for (const name of associatedNames) {
@@ -302,7 +305,9 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
            *  An empty answer intersects to nothing, which is the same
            *  fail-closed outcome the `authorization` branch below hard-codes
            *  for unfiltered endpoints, reached without inspecting headers. */
-          modelsConfig[name] = declared.filter((model) => fetchedModels.includes(model));
+          fetchedSet ??= new Set(fetchedModels);
+          const fetched = fetchedSet;
+          modelsConfig[name] = declared.filter((model) => fetched.has(model));
           continue;
         }
 

--- a/packages/api/src/endpoints/custom/config.spec.ts
+++ b/packages/api/src/endpoints/custom/config.spec.ts
@@ -83,3 +83,25 @@ describe('loadCustomEndpointsConfig – user credential prompts', () => {
     );
   });
 });
+
+describe('loadCustomEndpointsConfig – model labels', () => {
+  it('passes a declared label map to the client', () => {
+    const config = loadCustomEndpointsConfig([
+      {
+        ...baseEndpoint,
+        name: 'Claude',
+        modelLabels: { 'claude-sonnet-4-5': 'Sonnet 4.5' },
+      },
+    ] as unknown as TCustomEndpoints);
+
+    expect(config?.['Claude']?.modelLabels).toEqual({ 'claude-sonnet-4-5': 'Sonnet 4.5' });
+  });
+
+  it('leaves modelLabels undefined when the endpoint declares none', () => {
+    const config = loadCustomEndpointsConfig([
+      { ...baseEndpoint, name: 'Claude' },
+    ] as unknown as TCustomEndpoints);
+
+    expect(config?.['Claude']?.modelLabels).toBeUndefined();
+  });
+});

--- a/packages/api/src/endpoints/custom/config.ts
+++ b/packages/api/src/endpoints/custom/config.ts
@@ -31,6 +31,7 @@ export function loadCustomEndpointsConfig(
         name: configName,
         iconURL,
         modelDisplayLabel,
+        modelLabels,
         customParams,
         provider,
       } = endpoint;
@@ -59,6 +60,7 @@ export function loadCustomEndpointsConfig(
         userProvideURL,
         customParams: resolvedCustomParams,
         modelDisplayLabel,
+        modelLabels,
         iconURL,
       };
     }

--- a/packages/api/src/endpoints/custom/config.ts
+++ b/packages/api/src/endpoints/custom/config.ts
@@ -1,6 +1,7 @@
 import { EModelEndpoint, extractEnvVariable, normalizeEndpointName } from 'librechat-data-provider';
 import type { TCustomEndpoints, TEndpoint } from 'librechat-data-provider';
 import type { TCustomEndpointsConfig } from '~/types/endpoints';
+import { hasModelSource } from '~/endpoints/config/availability';
 import { isUserProvided } from '~/utils';
 
 /**
@@ -19,11 +20,7 @@ export function loadCustomEndpointsConfig(
   if (Array.isArray(customEndpoints)) {
     const filteredEndpoints = customEndpoints.filter(
       (endpoint) =>
-        endpoint.baseURL &&
-        endpoint.apiKey &&
-        endpoint.name &&
-        endpoint.models &&
-        (endpoint.models.fetch || endpoint.models.default),
+        endpoint.baseURL && endpoint.apiKey && endpoint.name && hasModelSource(endpoint),
     );
 
     for (let i = 0; i < filteredEndpoints.length; i++) {

--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -1065,13 +1065,99 @@ describe('fetchModels caching behavior', () => {
     );
   });
 
-  it('skips MODEL_QUERIES cache when both headers and userObject are supplied (user-scoped response)', async () => {
+  it('caches a user-scoped response under its own key, with a short TTL', async () => {
     await fetchModels({
       apiKey: 'key',
       baseURL: 'https://api.test.com',
       name: 'TestAPI',
       headers: { Authorization: 'Bearer some-user-token' },
       userObject: { id: 'user-1' },
+    });
+
+    expect(mockCacheGet).toHaveBeenCalled();
+    expect(mockCacheSet).toHaveBeenCalledWith(
+      expect.any(String),
+      ['cached-model-1', 'cached-model-2'],
+      Time.THIRTY_SECONDS,
+    );
+  });
+
+  it('serves one user their own cached list across requests', async () => {
+    const params = {
+      apiKey: 'key',
+      baseURL: 'https://api.test.com',
+      name: 'TestAPI',
+      headers: { Authorization: 'Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}' },
+      userObject: { id: 'user-1' },
+    };
+
+    await fetchModels(params);
+    const firstKey = mockCacheSet.mock.calls[0][0];
+
+    mockCacheGet.mockResolvedValue(['from-cache']);
+    const second = await fetchModels(params);
+
+    expect(mockCacheGet).toHaveBeenLastCalledWith(firstKey);
+    expect(second).toEqual(['from-cache']);
+  });
+
+  it('never serves one user the list fetched for another', async () => {
+    const shared = {
+      apiKey: 'key',
+      baseURL: 'https://api.test.com',
+      name: 'TestAPI',
+      headers: { Authorization: 'Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}' },
+    };
+
+    await fetchModels({ ...shared, userObject: { id: 'user-1' } });
+    await fetchModels({ ...shared, userObject: { id: 'user-2' } });
+
+    const [keyOne, keyTwo] = mockCacheSet.mock.calls.map((call) => call[0]);
+    expect(keyOne).not.toEqual(keyTwo);
+  });
+
+  it('separates two endpoints that scope differently over one gateway', async () => {
+    const shared = {
+      apiKey: 'key',
+      baseURL: 'https://api.test.com',
+      userObject: { id: 'user-1' },
+    };
+
+    await fetchModels({
+      ...shared,
+      name: 'Scoped',
+      headers: { Authorization: 'Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}' },
+    });
+    await fetchModels({
+      ...shared,
+      name: 'Unscoped',
+      headers: { 'x-user-email': '{{LIBRECHAT_USER_EMAIL}}' },
+    });
+
+    const [keyOne, keyTwo] = mockCacheSet.mock.calls.map((call) => call[0]);
+    expect(keyOne).not.toEqual(keyTwo);
+  });
+
+  it('caches nothing when a user-scoped fetch has no identity to key on', async () => {
+    await fetchModels({
+      apiKey: 'key',
+      baseURL: 'https://api.test.com',
+      name: 'TestAPI',
+      headers: { Authorization: 'Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}' },
+      userObject: {},
+    });
+
+    expect(mockCacheGet).not.toHaveBeenCalled();
+    expect(mockCacheSet).not.toHaveBeenCalled();
+  });
+
+  it('still respects skipCache for a user-provided credential', async () => {
+    await fetchModels({
+      apiKey: 'key',
+      baseURL: 'https://api.test.com',
+      name: 'TestAPI',
+      userObject: { id: 'user-1' },
+      skipCache: true,
     });
 
     expect(mockCacheGet).not.toHaveBeenCalled();
@@ -1099,6 +1185,25 @@ describe('fetchModels caching behavior', () => {
     });
 
     expect(mockCacheGet).toHaveBeenCalled();
-    expect(mockCacheSet).toHaveBeenCalled();
+    /* Nothing scopes this response, so it keeps the shared key and TTL. */
+    expect(mockCacheSet).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      Time.TWO_MINUTES,
+    );
+  });
+
+  it("honours the caller's timeout", async () => {
+    await fetchModels({
+      apiKey: 'key',
+      baseURL: 'https://api.test.com',
+      name: 'TestAPI',
+      timeoutMs: 2000,
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ timeout: 2000 }),
+    );
   });
 });

--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -1192,18 +1192,4 @@ describe('fetchModels caching behavior', () => {
       Time.TWO_MINUTES,
     );
   });
-
-  it("honours the caller's timeout", async () => {
-    await fetchModels({
-      apiKey: 'key',
-      baseURL: 'https://api.test.com',
-      name: 'TestAPI',
-      timeoutMs: 2000,
-    });
-
-    expect(mockedAxios.get).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ timeout: 2000 }),
-    );
-  });
 });

--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -1065,7 +1065,7 @@ describe('fetchModels caching behavior', () => {
     );
   });
 
-  it('caches a user-scoped response under its own key, with a short TTL', async () => {
+  it('caches a user-scoped response under its own key, with its own TTL', async () => {
     await fetchModels({
       apiKey: 'key',
       baseURL: 'https://api.test.com',
@@ -1078,7 +1078,7 @@ describe('fetchModels caching behavior', () => {
     expect(mockCacheSet).toHaveBeenCalledWith(
       expect.any(String),
       ['cached-model-1', 'cached-model-2'],
-      Time.THIRTY_SECONDS,
+      Time.FIVE_MINUTES,
     );
   });
 

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -55,7 +55,16 @@ export interface FetchModelsParams {
   userObject?: Partial<IUser>;
   /** Skip MODEL_QUERIES cache (e.g., for user-provided keys) */
   skipCache?: boolean;
+  /** Request timeout in ms. Shorter is better where the caller can fall back. */
+  timeoutMs?: number;
 }
+
+/**
+ * Ceiling on a catalog fetch. A caller that degrades gracefully should pass
+ * something tighter — this bound is only reached when the gateway is unwell,
+ * and every millisecond of it is spent in front of a waiting user.
+ */
+export const DEFAULT_MODELS_FETCH_TIMEOUT_MS = 5000;
 
 function applyUserProvidedBaseURLProtection(
   options: AxiosRequestConfig,
@@ -165,6 +174,7 @@ export async function fetchModels({
   headers,
   userObject,
   skipCache = false,
+  timeoutMs = DEFAULT_MODELS_FETCH_TIMEOUT_MS,
 }: FetchModelsParams): Promise<string[]> {
   let models: string[] = [];
   const baseURL = direct ? extractBaseURL(_baseURL ?? '') : _baseURL;
@@ -182,17 +192,22 @@ export async function fetchModels({
     await validateEndpointURL(baseURL, name, allowedAddresses);
   }
 
-  // The MODEL_QUERIES cache is keyed by baseURL+apiKey only. That's safe
-  // when the response is identical for every caller, but fails when callers
-  // forward header templates that resolve to a user-bound value (e.g.
-  // `Authorization: Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}`): one user's
-  // filtered list could otherwise be served to the next request that
-  // shares the same baseURL+apiKey. Skip the cache whenever both `headers`
-  // and `userObject` are supplied, since that's the signal the caller is
-  // resolving headers against a specific user's identity.
+  // A response is user-scoped when the caller forwards header templates resolved
+  // against a specific user (e.g. `Authorization: Bearer
+  // {{LIBRECHAT_OPENID_ID_TOKEN}}`), or asks for the user to be named in the
+  // query. Keyed by baseURL+apiKey alone, one user's filtered list would be
+  // served to the next request sharing that gateway — so the key carries the
+  // requesting user and the header templates in play, and the entry lives only
+  // long enough to cover a page load rather than the full catalog TTL.
   const hasUserScopedHeaders = !!headers && Object.keys(headers).length > 0 && !!userObject;
-  const shouldCache = !skipCache && !(userIdQuery && user) && !hasUserScopedHeaders;
-  const cacheKey = shouldCache ? modelsCacheKey(baseURL ?? '', apiKey) : '';
+  const isUserScoped = hasUserScopedHeaders || !!(userIdQuery && user);
+  const scopeId = isUserScoped ? (userObject?.id ?? user ?? '') : '';
+  // No identity to key on: cache nothing rather than share one user's list.
+  const shouldCache = !skipCache && (!isUserScoped || scopeId !== '');
+  const cacheKey = shouldCache
+    ? modelsCacheKey(baseURL ?? '', apiKey, scopeId, isUserScoped ? headers : null)
+    : '';
+  const cacheTtl = isUserScoped ? Time.THIRTY_SECONDS : Time.TWO_MINUTES;
   const modelsCache = shouldCache ? standardCache(CacheKeys.MODEL_QUERIES) : null;
   if (modelsCache && cacheKey) {
     const cachedModels = await modelsCache.get(cacheKey);
@@ -227,7 +242,7 @@ export async function fetchModels({
     }
     if (ollamaModels !== null) {
       if (modelsCache && cacheKey && ollamaModels.length > 0) {
-        await modelsCache.set(cacheKey, ollamaModels, Time.TWO_MINUTES);
+        await modelsCache.set(cacheKey, ollamaModels, cacheTtl);
       }
       return ollamaModels;
     }
@@ -249,7 +264,7 @@ export async function fetchModels({
       headers: {
         ...resolvedHeaders,
       },
-      timeout: 5000,
+      timeout: timeoutMs,
     };
 
     if (name === EModelEndpoint.anthropic) {
@@ -303,14 +318,33 @@ export async function fetchModels({
   }
 
   if (modelsCache && cacheKey && models.length > 0) {
-    await modelsCache.set(cacheKey, models, Time.TWO_MINUTES);
+    await modelsCache.set(cacheKey, models, cacheTtl);
   }
 
   return models;
 }
 
-function modelsCacheKey(baseURL: string, apiKey: string): string {
-  return crypto.createHash('sha256').update(`${baseURL}:${apiKey}`).digest('hex').slice(0, 32);
+/**
+ * `scopeId` is the requesting user, empty for a response every caller shares.
+ *
+ * `headers` are the configured templates, not the resolved values: templates are
+ * static config, so they separate two endpoints that scope differently over one
+ * gateway while staying identical across a user's requests. Resolved values
+ * would not — several carry a per-request conversation or message id, and such a
+ * key would never be hit twice.
+ */
+function modelsCacheKey(
+  baseURL: string,
+  apiKey: string,
+  scopeId = '',
+  headers: Record<string, string> | null = null,
+): string {
+  const headerScope = headers ? JSON.stringify(Object.entries(headers).sort()) : '';
+  return crypto
+    .createHash('sha256')
+    .update(`${baseURL}:${apiKey}:${scopeId}:${headerScope}`)
+    .digest('hex')
+    .slice(0, 32);
 }
 
 /** Options for fetching OpenAI models */

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -197,8 +197,13 @@ export async function fetchModels({
   // {{LIBRECHAT_OPENID_ID_TOKEN}}`), or asks for the user to be named in the
   // query. Keyed by baseURL+apiKey alone, one user's filtered list would be
   // served to the next request sharing that gateway — so the key carries the
-  // requesting user and the header templates in play, and the entry lives only
-  // long enough to cover a page load rather than the full catalog TTL.
+  // requesting user and the header templates in play.
+  //
+  // A stale entry cannot grant anything: the gateway rejects a call for a model
+  // the user lacks either way, so the cost is a list that lags a revoked grant
+  // or a newly rolled-out model. Five minutes keeps a gateway-side rollout
+  // feeling prompt while covering far more than the three requests a page load
+  // makes.
   const hasUserScopedHeaders = !!headers && Object.keys(headers).length > 0 && !!userObject;
   const isUserScoped = hasUserScopedHeaders || !!(userIdQuery && user);
   const scopeId = isUserScoped ? (userObject?.id ?? user ?? '') : '';
@@ -207,7 +212,7 @@ export async function fetchModels({
   const cacheKey = shouldCache
     ? modelsCacheKey(baseURL ?? '', apiKey, scopeId, isUserScoped ? headers : null)
     : '';
-  const cacheTtl = isUserScoped ? Time.THIRTY_SECONDS : Time.TWO_MINUTES;
+  const cacheTtl = isUserScoped ? Time.FIVE_MINUTES : Time.TWO_MINUTES;
   const modelsCache = shouldCache ? standardCache(CacheKeys.MODEL_QUERIES) : null;
   if (modelsCache && cacheKey) {
     const cachedModels = await modelsCache.get(cacheKey);

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -55,16 +55,7 @@ export interface FetchModelsParams {
   userObject?: Partial<IUser>;
   /** Skip MODEL_QUERIES cache (e.g., for user-provided keys) */
   skipCache?: boolean;
-  /** Request timeout in ms. Shorter is better where the caller can fall back. */
-  timeoutMs?: number;
 }
-
-/**
- * Ceiling on a catalog fetch. A caller that degrades gracefully should pass
- * something tighter — this bound is only reached when the gateway is unwell,
- * and every millisecond of it is spent in front of a waiting user.
- */
-export const DEFAULT_MODELS_FETCH_TIMEOUT_MS = 5000;
 
 function applyUserProvidedBaseURLProtection(
   options: AxiosRequestConfig,
@@ -174,7 +165,6 @@ export async function fetchModels({
   headers,
   userObject,
   skipCache = false,
-  timeoutMs = DEFAULT_MODELS_FETCH_TIMEOUT_MS,
 }: FetchModelsParams): Promise<string[]> {
   let models: string[] = [];
   const baseURL = direct ? extractBaseURL(_baseURL ?? '') : _baseURL;
@@ -269,7 +259,7 @@ export async function fetchModels({
       headers: {
         ...resolvedHeaders,
       },
-      timeout: timeoutMs,
+      timeout: 5000,
     };
 
     if (name === EModelEndpoint.anthropic) {

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -248,6 +248,50 @@ describe('endpointSchema deprecated fields', () => {
   });
 });
 
+describe('endpointSchema modelLabels', () => {
+  const validEndpoint = {
+    name: 'CustomEndpoint',
+    apiKey: 'test-key',
+    baseURL: 'https://api.example.com',
+    models: { default: ['claude-opus-4-8'] },
+  };
+
+  it('keeps a declared label map, which is otherwise stripped as an unknown key', () => {
+    const result = endpointSchema.safeParse({
+      ...validEndpoint,
+      modelLabels: { 'claude-opus-4-8': 'Opus 4.8' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelLabels).toEqual({ 'claude-opus-4-8': 'Opus 4.8' });
+    }
+  });
+
+  it('accepts labels for models the endpoint does not declare, so one map can cover a fleet', () => {
+    const result = endpointSchema.safeParse({
+      ...validEndpoint,
+      modelLabels: { 'claude-opus-4-8': 'Opus 4.8', 'claude-opus-5': 'Opus 5' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('is optional', () => {
+    const result = endpointSchema.safeParse(validEndpoint);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelLabels).toBeUndefined();
+    }
+  });
+
+  it('rejects a non-string label', () => {
+    const result = endpointSchema.safeParse({
+      ...validEndpoint,
+      modelLabels: { 'claude-opus-4-8': 4.8 },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe('endpointSchema addParams validation', () => {
   const validEndpoint = {
     name: 'CustomEndpoint',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -855,6 +855,14 @@ export const endpointSchema = baseEndpointSchema.merge(
     iconURL: z.string().optional(),
     modelDisplayLabel: z.string().optional(),
     /**
+     * Display-only labels for this endpoint's models, keyed by model id
+     * (`claude-opus-4-8: 'Opus 4.8'`). Purely presentational: the id remains
+     * what is declared, fetched, matched and sent upstream, and a model with no
+     * entry renders its id. A label for a model this endpoint does not serve is
+     * inert, so one map can cover a fleet of deployments.
+     */
+    modelLabels: z.record(z.string()).optional(),
+    /**
      * Forces the endpoint to use a provider's native client / request format
      * instead of the default OpenAI-compatible client. Currently supports
      * `anthropic`, for endpoints that speak the Anthropic `/v1/messages` API

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -835,8 +835,21 @@ export const endpointSchema = baseEndpointSchema.merge(
     apiKey: z.string(),
     baseURL: z.string(),
     models: z.object({
-      default: z.array(modelItemSchema).min(1),
+      /**
+       * The models this endpoint may serve. With `filter`, this is an allowlist
+       * intersected against the fetched catalog rather than a fallback list, so
+       * an empty array is meaningful: it declares an endpoint that shows only
+       * what a deployment actually has, and nothing until it has something.
+       */
+      default: z.array(modelItemSchema),
       fetch: z.boolean().optional(),
+      /**
+       * Serves `default ∩ fetched` instead of replacing `default` with the
+       * fetched list. Lets endpoints sharing one gateway (same baseURL, apiKey
+       * and headers, hence one coalesced fetch) each present their own slice of
+       * that gateway's catalog, without a per-deployment list to maintain.
+       */
+      filter: z.boolean().optional(),
       userIdQuery: z.boolean().optional(),
     }),
     iconURL: z.string().optional(),

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -443,6 +443,7 @@ export type TConfig = {
   iconURL?: string;
   version?: string;
   modelDisplayLabel?: string;
+  modelLabels?: Record<string, string>;
   userProvide?: boolean | null;
   userProvideURL?: boolean | null;
   userProvideAccessKeyId?: boolean;


### PR DESCRIPTION
## Why

We front LiteLLM with several custom endpoints — one per provider dialect, because `customParams.defaultParamsEndpoint` is what selects the Anthropic/Google request builder, and Claude models are measurably worse on the OpenAI builder. All of those endpoints share one `baseURL`, `apiKey` and header set.

Today they cannot have different model lists:

- With `fetch: true`, a successful fetch **replaces** `models.default` wholesale, so every endpoint advertises LiteLLM's entire catalog — including embeddings, rerankers and OCR models, each on the wrong dialect.
- With `fetch: false` and curated lists, the lists come apart but nothing tracks reality any more: a model retired in LiteLLM lingers in the picker, and the per-user catalog our OIDC endpoints already return collapses to one static list for everyone.

There is no third option in config, which is what this PR adds.

The same split leaves a second gap. Once the model list comes from the gateway, every row in the picker is a raw model id — `claude-opus-4-8`, `gpt-5.4-nano`. Agents and assistants get a name to show instead; no other endpoint does. Commits 5 and 6 give an endpoint somewhere to put a human label.

## What

Six commits, reviewable in order.

### 1. `models.filter` — declared ∩ fetched

`models.default` becomes an allowlist rather than a fallback: the endpoint serves the declared names the gateway actually returned, in declared order. Declaring a model a deployment does not have is inert, so one shared list covers a fleet where each deployment holds a subset, and rolling a model out becomes a gateway-side change with no config edit.

Supporting changes:

- `models.default` no longer requires one entry — an empty declared list is now meaningful (a template a deployment fills in).
- Both prefilters deciding whether an endpoint has any model source tested `models.default` for **truthiness**, and `[]` is truthy. They now test length, and share one predicate instead of holding two copies of it.
- A fetch that never answered is kept distinct from a fetch that answered with nothing.

### 2. One models-config resolution per request

`getModelsConfig` is reached from seven places per page (models route, startup-config spec pruning, `validateModel`, token config, agent initialization, both agent response controllers) and each re-ran the full resolution including a live `/models` call per gateway. `MODEL_QUERIES` cannot absorb it — `fetchModels` skips that cache whenever an endpoint forwards user-bound headers, and must, since the response is identity-scoped. Memoized on the request object instead; a failure evicts so a later caller can retry.

### 3. Withhold endpoints with nothing to serve

An endpoint's existence is decided by declaration, never content, so an empty endpoint still renders — `useEndpoints` computes `hasModels` but drops only `agents`, and the agent builder offers it as a provider with no model to pick. Already reachable today: an endpoint sending an `authorization` header whose fetch returns nothing gets `[]` rather than the declared fallback. Now withheld from the endpoints config, which is the single object the selector, the agent builder and spec pruning all derive from.

Custom endpoints only. Fails open — only an explicit empty list withholds an endpoint.

### 4. No violation for a request to an endpoint with nothing to offer

`validateModel` treats any model absent from an endpoint's list as an `ILLEGAL_MODEL_REQUEST`, which carries a violation score and contributes toward a ban. That reading only holds when the endpoint *has* models and the requested one is not among them.

An endpoint whose list is empty is unavailable, and the requests that arrive are stored conversations and agents naming an endpoint that has stopped serving them — commit 3 makes that an ordinary state. Their owners would collect violations for a configuration change they had no part in. Those are now rejected as "Endpoint unavailable" without logging. An unlisted model on an endpoint that does have models still logs, unchanged.

### 5. `modelLabels` — display labels on the endpoint

An endpoint-level `Record<modelId, label>`, alongside `modelDisplayLabel` and following `tokenConfig`, passed through to the client.

Display-only. The id stays what is declared, fetched, intersected, selected, stored on the conversation and sent upstream, so a label is safe to change at any time and a model with no entry renders its id.

Not routed through `models.default`: `modelItemSchema` has no `label`, and both the declared and the fetched path resolve to bare id strings, so `modelsConfig` is a `Record<string, string[]>` and stays that way. Keeping the map on the endpoint also means a label for a model that endpoint does not serve is simply never rendered — one map covers a fleet where each deployment serves a subset, which is the same property commit 1 gives the declared list.

### 6. Render the label

One helper, `getModelName`, returns the agent name, the assistant name or the declared label for a model, and `undefined` when there is none so each caller keeps its own fallback. An empty string counts as no name — that is what `agentNames` stores for an unnamed agent.

Five sites read it: the endpoint's model list, a search result row, the selector's closed trigger, the announcement made on selecting a model, and the Agent Builder's model combobox. The last matters most on deployments setting `modelSpecs.addedEndpoints: [agents]`, where provider endpoints are kept out of the selector entirely and the Agent Builder is the only place a user meets a model id.

Search covers the label and the id, across all three filters — which endpoints survive a query, the open endpoint's list, and the search results' own predicate. A label is additive there: both strings match. An agent or assistant name still replaces the id, unchanged.

Selection is untouched: `handleSelectModel` and `ControlCombobox` both keep the id as the value they hand back.

## Behaviour change to review deliberately

**A rejected fetch now falls back to the declared list for every endpoint, including those sending an `authorization` header.** Previously a rejected promise was flattened to `[]` before the header check, so those endpoints went empty during an outage.

This is intentional and paired with commit 3: once an empty list can remove an endpoint, treating an unreachable gateway as an authoritative empty would delete endpoints mid-blip and raise `INVALID_AGENT_PROVIDER` for stored agents naming them. The gateway, not this list, is the enforcement point — it rejects a call for a model the caller lacks regardless.

An *answer* of `[]` still yields nothing. For filtered endpoints that now falls out of the intersection without inspecting headers, so `hasAuthorizationHeader` should become redundant on the fulfilled path once every endpoint carries `filter: true` — left in place until that is confirmed on a live deployment.

## Blast radius

- **Commits 1–4 need no client changes.** `useEndpoints` and `AgentPanel` both derive from `endpointsConfig` / `modelsConfig`. Commits 5–6 touch the client, but only the string rendered for a model.
- **`filterModelSpecsByAvailability` untouched** — it starts pruning against real availability again as a consequence of getting a better list. Note it fails open on a *missing* key and closed on `[]`, which is why commit 1 keeps the key present.
- **`endpoints.agents.allowedProviders` unaffected** — `initialize.ts` rejects a provider *missing* from the list, so extra entries stay harmless.
- Existing endpoints without `filter` behave as before on the fulfilled path, OIDC empty-answer handling included.

## Tests

- `packages/api/src/endpoints/config/availability.spec.ts` — 16 new: intersection and declared order, two endpoints sharing one coalesced fetch, empty answer, rejected fetch with and without an `authorization` header, `filter` with no fetch, the empty-declaration prefilter, and three pinning unfiltered behaviour.
- `packages/api/src/endpoints/config/endpoints.spec.ts` — 7 new: withholding, built-ins never withheld, fail-open on error / on a missing key / with no resolver supplied.
- `api/server/services/Config/__tests__/getModelsConfig.spec.js` — 4 new: merge, one resolution per request, no sharing between requests, retry after failure.
- `api/server/middleware/__tests__/validateModel.spec.js` — 2 new: no violation on an empty list, violation still logged for an unlisted model.

- `packages/data-provider/specs/config-schemas.spec.ts` — 4 new: `modelLabels` survives parsing rather than being stripped as an unknown key, accepts labels for undeclared models, stays optional, rejects a non-string label.
- `packages/api/src/endpoints/custom/config.spec.ts` — 2 new: passed through to the client, absent when undeclared.
- `client/.../Endpoints/__tests__/utils.test.ts` — 9 new: `getModelName` precedence and its empty-name and null handling, label-and-id search through `filterItems` and `filterModels`, `getDisplayValue` labelled and unlabelled.
- `client/.../components/__tests__/EndpointModelItem.test.tsx` — 3 new: label rendered instead of the id, unlabelled model falls back, selection still keys on the id.
- `client/.../components/__tests__/SearchResults.test.tsx` — 3 new: found by label, found by id, selected by id.

Green: `packages/api` 6576 tests (the 20 remaining failures are the Redis `*_integration` suites plus one timing-sensitive `flow/manager` spec that passes in isolation — no local Redis), `packages/data-provider` 1254, and the client's `Endpoints` / `SidePanel/Agents` / `hooks/Endpoint` suites, 168.

The `api` suite is flaky on this baseline — three consecutive runs gave 2, 4 and 3 failures out of 2976, all in `strategies/openIdJwtStrategy`, the OpenID cookie suites, `requestPasswordReset` and the CloudFront cookie suite. None sits in a path this branch touches. The two stable ones were reproduced at `650e62089` with this branch's changes reverted and both packages rebuilt. The subset covering everything changed here — `server/services/Config`, `server/middleware`, `server/controllers`, `server/routes`, 1349 tests — passes.

Not yet exercised against a live gateway; that is the next step on `apro-sandbox`.

## One thing this does not fix

`RemoteAgents` / `Remote`-style endpoints — `fetch: true`, no `filter`, authenticating as a shared key — still replace their declared list with the gateway's whole catalog. That is what `filter` is for; adopting it there is a config change, not a code one.

